### PR TITLE
Add a test for empty strings

### DIFF
--- a/test/spec.toml
+++ b/test/spec.toml
@@ -7,6 +7,7 @@ false = false
 [strings]
 # String
 string = "string\n\t\"string"
+empty = ""
 
 [ints]
 simple = 42

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -10,9 +10,10 @@ class TestParser < MiniTest::Unit::TestCase
     filepath = File.join(File.dirname(__FILE__), 'spec.toml')
     @doc = TOML::Parser.new(File.read(filepath)).parsed
   end
-  
+
   def test_string
     assert_equal "string\n\t\"string", @doc["strings"]["string"]
+    assert_equal "", @doc["strings"]["empty"]
   end
 
   def test_integer


### PR DESCRIPTION
Empty strings are currently parsed as arrays. I only wrote the test because I'm unsure of how to fix it.

It appears that the empty string is being parsed as a key. The following rule gets a subtree `v` that is `{string: []}`: https://github.com/jm/toml/blob/fced48ec1b30daa3b89032f005d8e125d5c75950/lib/toml/transformer.rb#L79-L81
