### PR TITLE
Multiline arrays can have trailing commas

### DIFF
--- a/lib/toml/parslet.rb
+++ b/lib/toml/parslet.rb
@@ -29,6 +29,7 @@ module TOML
           # Value followed by any comments
           all_space >> value >> array_comments
         ).repeat >>
+        (all_space >> str(",")).maybe >> # possible trailing comma
         all_space >> array_comments # Grab any remaining comments just in case
       ).maybe.as(:array) >> str("]") 
     }

--- a/test/spec.toml
+++ b/test/spec.toml
@@ -47,6 +47,13 @@ multiline = [
 	3
 ]
 
+# Multiline array
+multiline_trailing_comma = [
+	1,
+	2,
+	3,
+]
+
 # With comments
 multiline_comments = [ # 0
 	1, # 1

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -52,11 +52,15 @@ class TestParser < MiniTest::Unit::TestCase
   def test_multiline_arrays
     assert_equal ["lines", "are", "super", "cool", "lol", "amirite"], @doc["arrays"]["multi"]
   end
-  
+
   def test_multiline_array
     assert_equal @doc["arrays"]["multiline"], [1, 2, 3]
   end
-  
+
+  def test_multiline_array_with_trailing_comma
+    assert_equal @doc["arrays"]["multiline_trailing_comma"], [1, 2, 3]
+  end
+
   def test_multiline_array_with_comments
     assert_equal @doc["arrays"]["multiline_comments"], [1, 2, 3]
   end


### PR DESCRIPTION
The Array section of the TOML spec says "Terminating commas are ok before the closing bracket". This pull request makes that happen.
