### PR TITLE
Change version constraint in multi_json dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'multi_json', '~> 1.7.8'
+  gem 'multi_json', '~> 1.7'
   gem 'minitest'
   gem 'simplecov', :require => false
   gem 'simplecov-gem-adapter', :require => false


### PR DESCRIPTION
Upstream for multi_json suggests using pessimistic version constraints
with two digits for dependencies. In particular, upstream is now at
version 1.8.4, which breaks the given dependency, while all tests are
still successfull.
