### PR TITLE
Update parslet dependency to a version that has more relaxed blankslate requirements

### DIFF
--- a/toml.gemspec
+++ b/toml.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md LICENSE CHANGELOG.md]
 
-  s.add_dependency "parslet", "~> 1.5.0"
+  s.add_dependency "parslet", "~> 1.6.2"
 
   s.add_development_dependency "rake"
 


### PR DESCRIPTION
When integrating jekyll with a project that has dependencies which require a newer (>= 3.0) version of  blankslate there are conflicts with the 2.x version of blankslate that parslet 1.5.0 requires.

This small change updates parslet to a version that relaxed the blankslate requirement to >= 2.0 and <= 4.0.

kschiess/parslet@70e3138bc9c8fd663cf93bc69a4c2bb8b80f3852 is the important change in parslet that addresses the blankslate dependency.

The test suite still passes with parslet 1.6.2.