### PR TITLE
make toml work with parslet >= 1.7

### DIFF
--- a/lib/toml/transformer.rb
+++ b/lib/toml/transformer.rb
@@ -92,23 +92,23 @@ module TOML
     # Make key hashes (inside key_groups) just be strings
     rule(:key => simple(:k)) { k }
 
-    # Then objectify the key_groups
-    rule(:table => simple(:kg)) {
-      Table.new([kg.to_s])
-    }
-
     # Captures array-like key-groups
     rule(:table => subtree(:kg)) {
       Table.new(kg.map &:to_s)
     }
     
-    # Single name table-arrays
-    rule(:table_array => simple(:name)) {
-      TableArray.new([name.to_s])
+    # Then objectify the key_groups
+    rule(:table => simple(:kg)) {
+      Table.new([kg.to_s])
     }
+
     # Multi-part (a.b.c) table-arrays
     rule(:table_array => subtree(:names)) {
       TableArray.new(names.map &:to_s)
+    }
+    # Single name table-arrays
+    rule(:table_array => simple(:name)) {
+      TableArray.new([name.to_s])
     }
   end
 end

--- a/toml.gemspec
+++ b/toml.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md LICENSE CHANGELOG.md]
 
-  s.add_dependency "parslet", "~> 1.6.2"
+  s.add_dependency "parslet", "~> 1.7.1"
 
   s.add_development_dependency "rake"
 


### PR DESCRIPTION
This change makes toml work with newer parslet. As the order of insertion of rules have changed in parslet to give newer rules higher priority, rules have been exchanged in transform.rb.

This closes #43.
