### PR TITLE
Drop Rails 2.3 warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ A sane configuration format from @mojombo.  More information here: https://githu
 
 This is far superior to YAML and JSON because it doesn't suck.  Really it doesn't.
 
-**There is a bug in Rails 2.3's vendored version of BlankSlate (a dependency of Parslet which is used for parsing TOML) that breaks Parslet; please see this [Gist](https://gist.github.com/dirk/5264004) for a workaround.**
-
 ## Usage
 
 Add to your Gemfile:


### PR DESCRIPTION
Virtually no-one is using Rails 2 these days (5.2 is the latest release) so I suggest we drop this warning.