### PR TITLE
Fix printing of parse failure (`cause` renamed to `parse_failure_cause` in parslet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+- Fix "undefined method `ascii_tree' for nil:NilClass" when printing parse error
+
 ## 0.1.2 / 2014-10-16
 
 - Add support for `CR` and `CRLF` newlines (#13)

--- a/lib/toml/parser.rb
+++ b/lib/toml/parser.rb
@@ -9,7 +9,7 @@ module TOML
       begin
         tree = Parslet.new.parse(markup)
       rescue Parslet::ParseFailed => failure
-        puts failure.cause.ascii_tree
+        puts failure.parse_failure_cause.ascii_tree
       end
       
       

--- a/test/test_failure.rb
+++ b/test/test_failure.rb
@@ -1,0 +1,15 @@
+require "bundler/setup"
+require "toml"
+require "minitest/autorun"
+
+class TestFailure < MiniTest::Test
+  def test_failure
+    result = nil
+    out, _err = capture_io do
+      result = TOML::Parser.new("abc*123(")
+    end
+
+    assert_match(/line 1.*char 1/, out)
+    assert_equal({}, result.parsed)
+  end
+end


### PR DESCRIPTION
When parse error happens, this exception is raised, which is non-informative:

```
NoMethodError: undefined method `ascii_tree' for nil:NilClass
    /Users/kolen/items/toml/lib/toml/parser.rb:12:in `rescue in initialize'
    /Users/kolen/items/toml/lib/toml/parser.rb:9:in `initialize'
```

This is due to API change in `parslet`: as `Exception` superclass has `cause` method, parse failure cause method [had been renamed to `parse_failure_cause`](https://github.com/kschiess/parslet/commit/8b3b9d268309222f48e9843de65f65a6abef8031#diff-65d43e45c8699a2b309d71d46ae0f304). This change first appeared in parslet 1.8.0, which is already listed as minimum in gemspec.

_BTW, it might be unexpected for calling code that parse errors are ignored; and that empty, but valid result is returned. But that's another issue, I didn't try to change that, I just fixed existing behavior_