### PR TITLE
Serialize DateTime to RFC3339 format in 'toml.body'

### DIFF
--- a/lib/toml/monkey_patch.rb
+++ b/lib/toml/monkey_patch.rb
@@ -82,6 +82,6 @@ class Numeric
 end
 class DateTime
   def to_toml(path = "")
-    self.to_time.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    self.rfc3339
   end
 end


### PR DESCRIPTION
To serialize a TOML::Generator object to a TOML string, the user can use the '.body' method. This way all Ruby objects will be converted to a string encoded in TOML format.

If one of the objects is a DateTime object, the serialization code was incorrectly transforming it to a string by using the strftime() method with an argument that omits the timezone information. So if the
serialization code was executed on a machine that uses e.g. CET timezone, the resulting string contained the date offseted by -1 hours, without any information about timezone, so without any hint that the date is incorrect.

The test case 'test_generator' was failing because of this behavior.

The fix is to change the way DateTime is converted to the string. Instead of using 'strftime()' function with a custom argument, the code now uses the 'rfc3339()' method. This way the resulting string includes timezone information along with the date itself.