### PR TITLE
Serialize DateTime to RFC3339 format in 'toml.body'

### DIFF
--- a/lib/toml/monkey_patch.rb
+++ b/lib/toml/monkey_patch.rb
@@ -82,6 +82,6 @@ class Numeric
 end
 class DateTime
   def to_toml(path = "")
-    self.to_time.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    self.rfc3339
   end
 end

--- a/lib/toml/parslet.rb
+++ b/lib/toml/parslet.rb
@@ -11,6 +11,7 @@ module TOML
       array |
       string |
       datetime.as(:datetime) |
+      datetime_rfc3339.as(:datetime_rfc3339) |
       float.as(:float) |
       integer.as(:integer) |
       boolean
@@ -98,6 +99,16 @@ module TOML
       match["0-9"].repeat(2,2)
     }
 
+    rule(:timezone) {
+      match["0-9"].repeat(2,2) >> str(":") >>
+      match["0-9"].repeat(2,2)
+    }
+
     rule(:datetime) { date >> str("T") >> time >> str("Z") }
+
+    rule(:datetime_rfc3339) {
+      # rfc3339 section 5.6 allows replacing 'T' with a space.
+      date >> (str("T") | str(" ")) >> time >> (str("+") | str("-")) >> timezone
+    }
   end
 end

--- a/lib/toml/transformer.rb
+++ b/lib/toml/transformer.rb
@@ -52,6 +52,7 @@ module TOML
       ""
     }
     rule(:datetime => simple(:d)) { DateTime.iso8601(d) }
+    rule(:datetime_rfc3339 => simple(:d)) { DateTime.rfc3339(d) }
     rule(:true => simple(:b)) { true }
     rule(:false => simple(:b)) { false }
     


### PR DESCRIPTION
To serialize a TOML::Generator object to a TOML string, the user can use the '.body' method. This way all Ruby objects will be converted to a string encoded in TOML format.

If one of the objects is a DateTime object, the serialization code was incorrectly transforming it to a string by using the strftime() method with an argument that omits the timezone information. So if the
serialization code was executed on a machine that uses e.g. CET timezone, the resulting string contained the date offseted by -1 hours, without any information about timezone, so without any hint that the date is incorrect.

The test case 'test_generator' was failing because of this behavior.

The fix is to change the way DateTime is converted to the string. Instead of using 'strftime()' function with a custom argument, the code now uses the 'rfc3339()' method. This way the resulting string includes timezone information along with the date itself.