### PR TITLE
Don't catch Parslet::ParseError exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ TOML.load_file("my_file.toml")
 # => {"whatever" => "keys"}
 ```
 
+In case a syntax error occurs, the parser will raise a `Parslet::ParseFailed` exception.
+
 There's also a beta feature for generating a TOML file from a Ruby hash. Please note this will likely not give beautiful output right now.
 
 ```ruby

--- a/lib/toml/parser.rb
+++ b/lib/toml/parser.rb
@@ -6,13 +6,8 @@ module TOML
       # Make sure we have a newline on the end
       
       markup += "\n" unless markup.end_with?("\n") || markup.length == 0
-      begin
-        tree = Parslet.new.parse(markup)
-      rescue Parslet::ParseFailed => failure
-        puts failure.cause.ascii_tree
-      end
-      
-      
+      tree = Parslet.new.parse(markup)
+
       parts = Transformer.new.apply(tree) || []
       @parsed = {}
       @current = @parsed


### PR DESCRIPTION
Allow this error to be propagated to the caller. This way the user will be able to catch the exception, and react accordingly.

Fixes #47.