### PR TITLE
Parslet dependency bump

### DIFF
--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -39,23 +39,23 @@ class TestGenerator < MiniTest::Test
       "date" => DateTime.now,
       "nil" => nil
     }
-    
+
   end
-  
+
   def test_generator
     doc = @doc.clone
     body = TOML::Generator.new(doc).body
 
     doc_parsed = TOML::Parser.new(body).parsed
-    
+
     # removing the nil value
     remove_nil = doc.delete "nil"
     remove_nil_table = doc["key"].delete "nil_table"
-    
+
     # Extracting dates since Ruby's DateTime equality testing sucks.
     original_date = doc.delete "date"
     parsed_date = doc_parsed.delete "date"
-    assert_equal original_date.to_time.to_s, parsed_date.to_time.to_s
+    assert_equal original_date.to_time.utc.to_s, parsed_date.to_time.utc.to_s
 
     refute doc_parsed.length > doc.length, "Parsed doc has more items than we started with."
     doc.each do |key, val|

--- a/toml.gemspec
+++ b/toml.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md LICENSE CHANGELOG.md]
 
-  s.add_dependency "parslet", "~> 1.8.0"
+  s.add_dependency "parslet", ">= 1.8.0", "< 3.0.0"
 
   s.add_development_dependency "rake"
 


### PR DESCRIPTION
Parslet version 2.0 was [released](https://rubygems.org/gems/parslet/versions) in February and [addressed](https://github.com/kschiess/parslet/blob/master/HISTORY.txt) some issues in Ruby 2.6+. There are a few breaking changes from v1.8.2, but TOML is not affected by them. This PR updates the Parslet dependency to avoid version conflicts with libraries and applications that require the 2.0 version.