### PR TITLE
Fix issue with bare keys prefixed with # not being interpreted as a c…

### DIFF
--- a/lib/toml/parslet.rb
+++ b/lib/toml/parslet.rb
@@ -2,7 +2,7 @@ module TOML
   class Parslet < ::Parslet::Parser
     rule(:document) {
       all_space >>
-      (table | table_array | key_value | comment_line).repeat >>
+      (comment_line | table | table_array | key_value).repeat >>
       all_space
     }
     root :document
@@ -15,11 +15,11 @@ module TOML
       integer.as(:integer) |
       boolean
     }
-    
+
     # Finding comments in multiline arrays requires accepting a bunch of
     # possible newlines and stuff before the comment
     rule(:array_comments) { (all_space >> comment_line).repeat }
-    
+
     rule(:array) {
       str("[") >> all_space >> array_comments >>
       ( array_comments >> # Match any comments on first line
@@ -32,10 +32,10 @@ module TOML
         ).repeat >>
         (all_space >> str(",")).maybe >> # possible trailing comma
         all_space >> array_comments # Grab any remaining comments just in case
-      ).maybe.as(:array) >> str("]") 
+      ).maybe.as(:array) >> str("]")
     }
-    
-    rule(:key_value) { 
+
+    rule(:key_value) {
       space >> key.as(:key) >>
       space >> str("=") >>
       space >> value.as(:value) >>
@@ -53,7 +53,7 @@ module TOML
       str("]]") >>
       space >> comment.maybe >> str("\n") >> all_space
     }
-    
+
     rule(:key) { match["^. \t\\]"].repeat(1) }
     rule(:table_name) { key.as(:key) >> (str(".") >> key.as(:key)).repeat }
 
@@ -63,17 +63,17 @@ module TOML
     rule(:space) { match[" \t"].repeat }
     rule(:all_space) { match[" \t\r\n"].repeat }
     rule(:newline) { str("\r").maybe >> str("\n") | str("\r") >> str("\n").maybe }
-        
+
     rule(:string) {
       str('"') >> (
       match["^\"\\\\"] |
       (str("\\") >> match["0tnr\"\\\\"])
       ).repeat.as(:string) >> str('"')
     }
-    
+
     rule(:sign) { str("-") }
     rule(:sign?) { sign.maybe }
-    
+
     rule(:integer) {
       str("0") | sign? >>
       (match["1-9"] >> (match["_"].maybe >> match["0-9"]).repeat)
@@ -85,7 +85,7 @@ module TOML
     }
 
     rule(:boolean) { str("true").as(:true) | str("false").as(:false) }
-    
+
     rule(:date) {
       match["0-9"].repeat(4,4) >> str("-") >>
       match["0-9"].repeat(2,2) >> str("-") >>

--- a/test/spec.toml
+++ b/test/spec.toml
@@ -34,9 +34,13 @@ d = "test"
 [e]
 f = "test"
 
-# Post line comment
+
 [comments]
+# Post line comment
 on = "a line" # with markup
+# Comment symbols prefixing bare keys are comment lines
+#nospacecomment = "this should not be parsed"
+
 
 # Multi-line arrays
 [arrays]

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -105,4 +105,8 @@ class TestParser < MiniTest::Test
   def test_inline_comment
     assert_equal "a line", @doc["comments"]["on"]
   end
+
+  def test_bare_key_with_comment_prefixed
+    assert_nil @doc["comments"]["#nospacecomment"]
+  end
 end


### PR DESCRIPTION
…omment line

From the Toml spec (https://toml.io/en/v1.0.0-rc.3):

__"Bare keys may only contain ASCII letters, ASCII digits, underscores, and dashes (A-Za-z0-9_-). Note that bare keys are allowed to be composed of only ASCII digits, e.g. 1234, but are always interpreted as strings."__

This means the following should be interpreted as a comment line and not a value key/value pair:

```
#foobar = 3
```

However, as the `toml` gem codebase currently stands, this is interpreted as a string keyword which is typically represented in Toml with:

```
"#foobar" = 3
```

(As far as I could tell skimming the code base, only bare keys are currently supported anyway).

With this patch, we put precedence on comments, and therefore this matches a comment form rather than a keyword form earlier.

Note:

The rest of the tests still pass, although this precedence change could obviously have other ramifications that perhaps are not currently being tested.