### PR TITLE
Preserve hash structure when generating a TOML file

### DIFF
--- a/lib/toml/generator.rb
+++ b/lib/toml/generator.rb
@@ -1,19 +1,18 @@
-
-module TOML  
+module TOML
   class Generator
     attr_reader :body, :doc
 
-    def initialize(doc)
+    def initialize(doc, preserve = false)
       # Ensure all the to_toml methods are injected into the base Ruby classes
       # used by TOML.
       self.class.inject!
-      
+
       @doc = doc
-      @body = doc.to_toml
-      
-      return @body
+      @body = doc.to_toml("", preserve)
+
+      @body
     end
-    
+
     # Whether or not the injections have already been done.
     @@injected = false
     # Inject to_toml methods into the Ruby classes used by TOML (booleans,
@@ -22,8 +21,8 @@ module TOML
     # if something doesn't have a to_toml method).
     def self.inject!
       return if @@injected
-      require 'toml/monkey_patch'
+      require "toml/monkey_patch"
       @@injected = true
     end
-  end#Generator
-end#TOML
+  end # Generator
+end # TOML

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -1,9 +1,8 @@
+require "rubygems"
+require "bundler/setup"
 
-require 'rubygems'
-require 'bundler/setup'
-
-require 'toml'
-require 'minitest/autorun'
+require "toml"
+require "minitest/autorun"
 
 class TestGenerator < MiniTest::Test
   def setup
@@ -22,7 +21,7 @@ class TestGenerator < MiniTest::Test
           "name" => "second",
           "sub_table_array" => [
             {
-              "sub_name" => "sub first",
+              "sub_name" => "sub first"
             },
             {
               "sub_name" => "sub second"
@@ -39,7 +38,6 @@ class TestGenerator < MiniTest::Test
       "date" => DateTime.now,
       "nil" => nil
     }
-
   end
 
   def test_generator
@@ -61,5 +59,10 @@ class TestGenerator < MiniTest::Test
     doc.each do |key, val|
       assert_equal val, doc_parsed[key]
     end
+
+    # Test preserving the structure
+    body = TOML::Generator.new(doc, true).body
+    refute body.split.first != "integer", "The first entry in the generated TOML string is not 'integer' (as per @doc)."
+    assert_equal body.split.first, "integer"
   end
 end


### PR DESCRIPTION
For a given hash, preserve its structure when generating the TOML doc
string (via TOML::Generator.new(hash).body).  To do this, you would pass
in a boolean with the constructor for TOML::Generator.
```ruby
body = Generator.new(doc, false).body # Creates a TOML string that sorts the hash keys of 'doc'
body = Generator.new(doc, true).body # Creates a TOML string which preserves the structure of the the hash, 'doc'
```
The default value is false, mimicking the current behavior.
```ruby
body = Generator.new(doc).body # Creates a TOML string that sorts the hash keys of 'doc'
```

Fixes #69.