### PR TITLE
Periods allowed in key names

### DIFF
--- a/lib/toml/parslet.rb
+++ b/lib/toml/parslet.rb
@@ -55,7 +55,7 @@ module TOML
       space >> comment.maybe >> str("\n") >> all_space
     }
 
-    rule(:key) { match["^. \t\\]"].repeat(1) }
+    rule(:key) { match["^ \t\\]"].repeat(1) }
     rule(:table_name) { key.as(:key) >> (str(".") >> key.as(:key)).repeat }
 
     rule(:comment_line) { comment >> newline >> all_space }


### PR DESCRIPTION
According to [the
spec](https://github.com/toml-lang/toml/blob/cbf3b13128fb717517afbd22f8fcb665a0b0b035/toml.abnf#L73),
periods are allowed in key names.