### PR TITLE
Use Minitest instead of old MiniTest spelling

### DIFF
--- a/test/test_empty.rb
+++ b/test/test_empty.rb
@@ -4,7 +4,7 @@ require 'bundler/setup'
 require 'toml'
 require 'minitest/autorun'
 
-class TestEmpty < MiniTest::Test
+class TestEmpty < Minitest::Test
 
   def setup
     filepath = File.join(File.dirname(__FILE__), "empty.toml")

--- a/test/test_failure.rb
+++ b/test/test_failure.rb
@@ -2,7 +2,7 @@ require "bundler/setup"
 require "toml"
 require "minitest/autorun"
 
-class TestFailure < MiniTest::Test
+class TestFailure < Minitest::Test
   def test_failure
     assert_raises Parslet::ParseFailed do
       result = TOML::Parser.new("abc*123(")

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -5,7 +5,7 @@ require 'bundler/setup'
 require 'toml'
 require 'minitest/autorun'
 
-class TestGenerator < MiniTest::Test
+class TestGenerator < Minitest::Test
   def setup
     @doc = {
       "integer" => 1,

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -5,7 +5,7 @@ require 'bundler/setup'
 require 'toml'
 require 'minitest/autorun'
 
-class TestParser < MiniTest::Test
+class TestParser < Minitest::Test
   def setup
     filepath = File.join(File.dirname(__FILE__), 'spec.toml')
     @doc = TOML::Parser.new(File.read(filepath)).parsed

--- a/test/test_parser_hard.rb
+++ b/test/test_parser_hard.rb
@@ -3,7 +3,7 @@ require 'bundler/setup'
 require 'toml'
 require 'minitest/autorun'
 
-class TestParserHardExample < MiniTest::Test
+class TestParserHardExample < Minitest::Test
   def setup
     filepath = File.join(File.dirname(__FILE__), 'hard_example.toml')
     # @doc = TOML::Parser.new(File.read(filepath)).parsed

--- a/test/test_table_arrays.rb
+++ b/test/test_table_arrays.rb
@@ -3,7 +3,7 @@ require 'bundler/setup'
 require 'toml'
 require 'minitest/autorun'
 
-class TestParserTableArrays < MiniTest::Test
+class TestParserTableArrays < Minitest::Test
   def setup
     doc = '
 [[fruit]]


### PR DESCRIPTION
The old spelling MiniTest is not recognized by minitest v5 and higher.